### PR TITLE
Change format of returned keying material and cert fingerprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ After receiving initial DTLS packets on the second peer pass them to `ExDTLS`
 ```elixir
 {:ok, packets} = ExDTLS.do_handshake(dtls, packets)
 ```
-As a result we will also get some new packets that have to passed to the first peer.
+As a result, we will also get some new packets that have to be passed to the first peer.
 
 After some back and forth DTLS handshake should be finished successfully.
 Peer that finishes handshake first will return `{:finished_with_packets, handshake_data, packets}`

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ExDTLS
 
 [![Hex.pm](https://img.shields.io/hexpm/v/ex_dtls.svg)](https://hex.pm/packages/ex_dtls)
+[![API Docs](https://img.shields.io/badge/api-docs-yellow.svg?style=flat)](https://hexdocs.pm/ex_dtls/)
 [![CircleCI](https://circleci.com/gh/membraneframework/ex_dtls.svg?style=svg)](https://circleci.com/gh/membraneframework/ex_dtls)
 
 Elixir wrapper over [OpenSSL] for performing DTLS handshake (including DTLS-SRTP one).
@@ -39,12 +40,12 @@ After receiving initial DTLS packets on the second peer pass them to `ExDTLS`
 ```elixir
 {:ok, packets} = ExDTLS.do_handshake(dtls, packets)
 ```
-As a result we will also get some new  packets that have to passed to the first peer.
+As a result we will also get some new packets that have to passed to the first peer.
 
 After some back and forth DTLS handshake should be finished successfully.
-Peer that finishes handshake first will return `{:finished_with_packets, keying_material, packets}`
+Peer that finishes handshake first will return `{:finished_with_packets, handshake_data, packets}`
 message. These packets have to be sent to the second peer, so it can finish its handshake too and
-return `{:finished, keying_material}` message.
+return `{:finished, handshake_data}` message.
 
 
 For more complete examples please refer to [membrane_ice_plugin] where we use `ex_dtls`

--- a/c_src/ex_dtls/dtls.c
+++ b/c_src/ex_dtls/dtls.c
@@ -96,13 +96,20 @@ KeyingMaterial *export_keying_material(SSL *ssl) {
 
   KeyingMaterial *keying_material;
   keying_material = (KeyingMaterial *)malloc(sizeof(KeyingMaterial));
+  memset(keying_material, 0, sizeof(KeyingMaterial));
   keying_material->client =
       (unsigned char *)malloc(len / 2 * sizeof(unsigned char));
   keying_material->server =
       (unsigned char *)malloc(len / 2 * sizeof(unsigned char));
+  memset(keying_material->client, 0, len / 2);
+  memset(keying_material->server, 0, len / 2);
 
-  memcpy(keying_material->client, material, len / 2);
-  memcpy(keying_material->server, material + (len / 2), len / 2);
+  memcpy(keying_material->client, material, master_key_len);
+  memcpy(keying_material->server, material + master_key_len, master_key_len);
+  memcpy(keying_material->client + master_key_len,
+         material + 2 * master_key_len, master_salt_len);
+  memcpy(keying_material->server + master_key_len,
+         material + 2 * master_key_len + master_salt_len, master_salt_len);
   keying_material->protection_profile = profile->id;
   keying_material->len = len / 2;
 

--- a/c_src/ex_dtls/dtls.c
+++ b/c_src/ex_dtls/dtls.c
@@ -96,8 +96,10 @@ KeyingMaterial *export_keying_material(SSL *ssl) {
 
   KeyingMaterial *keying_material;
   keying_material = (KeyingMaterial *)malloc(sizeof(KeyingMaterial));
-  keying_material->client = (unsigned char *)malloc(len / 2 * sizeof(unsigned char));
-  keying_material->server = (unsigned char *)malloc(len / 2 * sizeof(unsigned char));
+  keying_material->client =
+      (unsigned char *)malloc(len / 2 * sizeof(unsigned char));
+  keying_material->server =
+      (unsigned char *)malloc(len / 2 * sizeof(unsigned char));
 
   memcpy(keying_material->client, material, len / 2);
   memcpy(keying_material->server, material + (len / 2), len / 2);
@@ -169,11 +171,9 @@ X509 *gen_cert(EVP_PKEY *pkey) {
   if (X509_NAME_add_entry_by_txt(name, "C", MBSTRING_ASC, (unsigned char *)"PL",
                                  -1, -1, 0) == 0 ||
       X509_NAME_add_entry_by_txt(name, "O", MBSTRING_ASC,
-                                 (unsigned char *)"ExDTLS", -1, -1,
-                                 0) == 0 ||
+                                 (unsigned char *)"ExDTLS", -1, -1, 0) == 0 ||
       X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC,
-                                 (unsigned char *)"ExDTLS", -1, -1,
-                                 0) == 0) {
+                                 (unsigned char *)"ExDTLS", -1, -1, 0) == 0) {
     DEBUG("Cannot set cert name");
     return NULL;
   }

--- a/c_src/ex_dtls/dtls.h
+++ b/c_src/ex_dtls/dtls.h
@@ -6,8 +6,15 @@
 #include <openssl/x509.h>
 #include <openssl/rsa.h>
 
+typedef struct KeyingMaterial {
+  unsigned char *client; // client keying material - master key + master salt
+  unsigned char *server;
+  unsigned int len; // len of client/server keying material
+  int protection_profile;
+} KeyingMaterial;
+
 SSL_CTX *create_ctx(int dtls_srtp);
 SSL *create_ssl(SSL_CTX *ssl_ctx, int client_mode);
-unsigned char *export_keying_material(SSL *ssl);
+KeyingMaterial *export_keying_material(SSL *ssl);
 EVP_PKEY *gen_key();
 X509 *gen_cert(EVP_PKEY *pkey);

--- a/c_src/ex_dtls/dtls.h
+++ b/c_src/ex_dtls/dtls.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <string.h>
-#include <openssl/ssl.h>
 #include <openssl/err.h>
-#include <openssl/x509.h>
 #include <openssl/rsa.h>
+#include <openssl/ssl.h>
+#include <openssl/x509.h>
+#include <string.h>
 
 typedef struct KeyingMaterial {
   unsigned char *client; // client keying material - master key + master salt

--- a/c_src/ex_dtls/dyn_buff.c
+++ b/c_src/ex_dtls/dyn_buff.c
@@ -1,34 +1,32 @@
 #include "dyn_buff.h"
 
 DynBuff *dyn_buff_new(int size) {
-    DynBuff *dyn_buff = (DynBuff*)malloc(sizeof(DynBuff));
-    dyn_buff->data = (char *)malloc(size * sizeof(char));
-    if (dyn_buff->data == NULL) {
-      fprintf(stderr, "Cannot allocate new dyn_buff with size: %d bytes", size);
-      free(dyn_buff);
-      exit(EXIT_FAILURE);
-    }
-    memset(dyn_buff->data, 0, size);
-    dyn_buff->size = size;
-    dyn_buff->data_size = 0;
-    return dyn_buff;
+  DynBuff *dyn_buff = (DynBuff *)malloc(sizeof(DynBuff));
+  dyn_buff->data = (char *)malloc(size * sizeof(char));
+  if (dyn_buff->data == NULL) {
+    fprintf(stderr, "Cannot allocate new dyn_buff with size: %d bytes", size);
+    free(dyn_buff);
+    exit(EXIT_FAILURE);
+  }
+  memset(dyn_buff->data, 0, size);
+  dyn_buff->size = size;
+  dyn_buff->data_size = 0;
+  return dyn_buff;
 }
 
 void dyn_buff_insert(DynBuff *dyn_buff, char *data, int size) {
-    if(dyn_buff->size - dyn_buff->data_size < size) {
-        int new_size = 2 * (dyn_buff->data_size + size);
-        dyn_buff->data = (char *)realloc(dyn_buff->data,  new_size);
-        if (dyn_buff->data == NULL) {
-          fprintf(stderr, "Cannot realloc dyn_buff to size: %d bytes", new_size);
-          dyn_buff_free(dyn_buff);
-          exit(EXIT_FAILURE);
-        }
-        dyn_buff->size = new_size;
+  if (dyn_buff->size - dyn_buff->data_size < size) {
+    int new_size = 2 * (dyn_buff->data_size + size);
+    dyn_buff->data = (char *)realloc(dyn_buff->data, new_size);
+    if (dyn_buff->data == NULL) {
+      fprintf(stderr, "Cannot realloc dyn_buff to size: %d bytes", new_size);
+      dyn_buff_free(dyn_buff);
+      exit(EXIT_FAILURE);
     }
-    memcpy(dyn_buff->data + dyn_buff->data_size, data, size);
-    dyn_buff->data_size += size;
+    dyn_buff->size = new_size;
+  }
+  memcpy(dyn_buff->data + dyn_buff->data_size, data, size);
+  dyn_buff->data_size += size;
 }
 
-void dyn_buff_free(DynBuff *dyn_buff) {
-  free(dyn_buff->data);
-}
+void dyn_buff_free(DynBuff *dyn_buff) { free(dyn_buff->data); }

--- a/c_src/ex_dtls/dyn_buff.c
+++ b/c_src/ex_dtls/dyn_buff.c
@@ -4,9 +4,8 @@ DynBuff *dyn_buff_new(int size) {
   DynBuff *dyn_buff = (DynBuff *)malloc(sizeof(DynBuff));
   dyn_buff->data = (char *)malloc(size * sizeof(char));
   if (dyn_buff->data == NULL) {
-    fprintf(stderr, "Cannot allocate new dyn_buff with size: %d bytes", size);
     free(dyn_buff);
-    exit(EXIT_FAILURE);
+    return NULL;
   }
   memset(dyn_buff->data, 0, size);
   dyn_buff->size = size;
@@ -14,19 +13,20 @@ DynBuff *dyn_buff_new(int size) {
   return dyn_buff;
 }
 
-void dyn_buff_insert(DynBuff *dyn_buff, char *data, int size) {
+int dyn_buff_insert(DynBuff *dyn_buff, char *data, int size) {
   if (dyn_buff->size - dyn_buff->data_size < size) {
     int new_size = 2 * (dyn_buff->data_size + size);
-    dyn_buff->data = (char *)realloc(dyn_buff->data, new_size);
-    if (dyn_buff->data == NULL) {
-      fprintf(stderr, "Cannot realloc dyn_buff to size: %d bytes", new_size);
+    char *new_data = (char *)realloc(dyn_buff->data, new_size);
+    if (new_data == NULL) {
       dyn_buff_free(dyn_buff);
-      exit(EXIT_FAILURE);
+      return -1;
     }
+    dyn_buff->data = new_data;
     dyn_buff->size = new_size;
   }
   memcpy(dyn_buff->data + dyn_buff->data_size, data, size);
   dyn_buff->data_size += size;
+  return 0;
 }
 
 void dyn_buff_free(DynBuff *dyn_buff) { free(dyn_buff->data); }

--- a/c_src/ex_dtls/dyn_buff.h
+++ b/c_src/ex_dtls/dyn_buff.h
@@ -6,10 +6,10 @@
 
 typedef struct DynBuff DynBuff;
 struct DynBuff {
-    // all sizes are in bytes
-    int size;
-    int data_size;
-    char *data;
+  // all sizes are in bytes
+  int size;
+  int data_size;
+  char *data;
 };
 
 DynBuff *dyn_buff_new(int size);

--- a/c_src/ex_dtls/dyn_buff.h
+++ b/c_src/ex_dtls/dyn_buff.h
@@ -14,4 +14,4 @@ struct DynBuff {
 
 DynBuff *dyn_buff_new(int size);
 void dyn_buff_free(DynBuff *dyn_buff);
-void dyn_buff_insert(DynBuff *dyn_buff, char *data, int size);
+int dyn_buff_insert(DynBuff *dyn_buff, char *data, int size);

--- a/c_src/ex_dtls/native.c
+++ b/c_src/ex_dtls/native.c
@@ -64,9 +64,15 @@ UNIFEX_TERM get_cert_fingerprint(UnifexEnv *env, State *state) {
   unsigned char md[EVP_MAX_MD_SIZE] = {0};
   unsigned int size;
   if (X509_digest(state->x509, EVP_sha256(), md, &size) != 1) {
-    get_cert_fingerprint_result_error_failed_to_get_fingerprint(env);
+    return unifex_raise(env, "Can't get cert fingerprint");
   }
-  return get_cert_fingerprint_result_ok(env, state, (char *)md);
+  UnifexPayload *payload = (UnifexPayload *)unifex_payload_alloc(
+            env, UNIFEX_PAYLOAD_BINARY, size);
+  memcpy(payload->data, md, size);
+  payload->size = size;
+  UNIFEX_TERM res_term = get_cert_fingerprint_result_ok(env, state, payload);
+  unifex_payload_release(payload);
+  return res_term;
 }
 
 UNIFEX_TERM do_handshake(UnifexEnv *env, State *state, UnifexPayload *payload) {

--- a/c_src/ex_dtls/native.h
+++ b/c_src/ex_dtls/native.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <unifex/unifex.h>
 #include "dtls.h"
+#include <unifex/unifex.h>
 
 typedef struct State State;
 

--- a/c_src/ex_dtls/native.spec.exs
+++ b/c_src/ex_dtls/native.spec.exs
@@ -10,5 +10,12 @@ spec get_cert_fingerprint(state) :: {:ok :: label, state, fingerprint :: string}
                                     | {:error :: label, :failed_to_get_fingerprint :: label}
 
 spec do_handshake(state, packets :: payload) :: {:ok :: label, state, packets :: payload}
-                            | {:finished_with_packets :: label, state, keying_material :: string, packets :: payload}
-                            | {:finished :: label, state, keying_material :: string}
+                            | {:finished_with_packets :: label, state,
+                                client_keying_material :: payload,
+                                server_keying_material :: payload,
+                                protection_profile :: int,
+                                packets :: payload}
+                            | {:finished :: label, state,
+                                client_keying_material :: payload,
+                                server_keying_material :: payload,
+                                protection_profile :: int}

--- a/c_src/ex_dtls/native.spec.exs
+++ b/c_src/ex_dtls/native.spec.exs
@@ -6,8 +6,7 @@ state_type "State"
 
 spec init(client_mode :: bool, dtls_srtp :: bool) :: {:ok :: label, state}
 
-spec get_cert_fingerprint(state) :: {:ok :: label, state, fingerprint :: string}
-                                    | {:error :: label, :failed_to_get_fingerprint :: label}
+spec get_cert_fingerprint(state) :: {:ok :: label, state, fingerprint :: payload}
 
 spec do_handshake(state, packets :: payload) :: {:ok :: label, state, packets :: payload}
                             | {:finished_with_packets :: label, state,

--- a/lib/ex_dtls.ex
+++ b/lib/ex_dtls.ex
@@ -92,12 +92,15 @@ defmodule ExDTLS do
       {:ok, _packets} ->
         {:reply, msg, state}
 
-      {:finished_with_packets, client_keying_material, server_keying_material, protection_profile, packets} ->
-        msg = {:finished_with_packets, {client_keying_material, server_keying_material, protection_profile}, packets}
+      {:finished_with_packets, client_keying_material, server_keying_material, protection_profile,
+       packets} ->
+        handshake_data = {client_keying_material, server_keying_material, protection_profile}
+        msg = {:finished_with_packets, handshake_data, packets}
         {:reply, msg, state}
 
       {:finished, client_keying_material, server_keying_material, protection_profile} ->
-        msg = {:finished, {client_keying_material, server_keying_material, protection_profile}}
+        handshake_data = {client_keying_material, server_keying_material, protection_profile}
+        msg = {:finished, handshake_data}
         {:reply, msg, state}
     end
   end

--- a/lib/ex_dtls.ex
+++ b/lib/ex_dtls.ex
@@ -61,7 +61,7 @@ defmodule ExDTLS do
   @doc """
   Returns a digest of the DER representation of the X509 certificate.
   """
-  @spec get_cert_fingerprint(pid :: pid()) :: {:ok, fingerprint :: String.t()}
+  @spec get_cert_fingerprint(pid :: pid()) :: {:ok, fingerprint :: binary()}
   def get_cert_fingerprint(pid) do
     GenServer.call(pid, :get_cert_fingerprint)
   end
@@ -122,12 +122,6 @@ defmodule ExDTLS do
   @impl true
   def handle_call(:get_cert_fingerprint, _from, %State{cnode: cnode} = state) do
     {:ok, digest} = Unifex.CNode.call(cnode, :get_cert_fingerprint)
-    {:reply, {:ok, hex_dump(digest)}, state}
-  end
-
-  defp hex_dump(digest_str) do
-    digest_str
-    |> :binary.bin_to_list()
-    |> Enum.map_join(":", &Base.encode16(<<&1>>))
+    {:reply, {:ok, digest}, state}
   end
 end

--- a/lib/ex_dtls.ex
+++ b/lib/ex_dtls.ex
@@ -32,10 +32,23 @@ defmodule ExDTLS do
           dtls_srtp: boolean()
         ]
 
+  @typedoc """
+  Supported protection profiles.
+
+  For meaning of these values please refer to
+  https://www.iana.org/assignments/srtp-protection/srtp-protection.xhtml
+  """
   @type protection_profile_t() :: 0x01 | 0x02 | 0x07 | 0x08
 
+  @typedoc """
+  Type describing data returned after successful handshake.
+
+  Both client and server keying materials consist of `master key` and `master salt`.
+  `client_keying_material` belongs to a peer working in a `client_mode`.
+  """
   @type handshake_data_t ::
-          {keying_material :: binary(), protection_profile :: protection_profile_t()}
+          {client_keying_material :: binary(), server_keying_material :: binary(),
+           protection_profile :: protection_profile_t()}
 
   @doc """
   Starts ExDTLS GenServer process linked to the current process.

--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,7 @@ defmodule ExDTLS.Mixfile do
   defp deps do
     [
       {:membrane_core, "~> 0.6.0"},
-      {:unifex, git: "https://github.com/membraneframework/unifex.git"},
+      {:unifex, "~> 0.3.2"},
       {:ex_doc, "~> 0.22", only: :dev, runtime: false},
       {:dialyxir, "~> 1.0.0", only: :dev, runtime: false},
       {:credo, "~> 1.4", only: :dev, runtime: false}

--- a/mix.lock
+++ b/mix.lock
@@ -20,5 +20,5 @@
   "secure_random": {:hex, :secure_random, "0.5.1", "c5532b37c89d175c328f5196a0c2a5680b15ebce3e654da37129a9fe40ebf51b", [:mix], [], "hexpm", "1b9754f15e3940a143baafd19da12293f100044df69ea12db5d72878312ae6ab"},
   "shmex": {:hex, :shmex, "0.3.0", "5b995fa0bba3ff48fb9a93fdd116f5e6f7c0012da00775564a8d29d199618b8c", [:mix], [{:bunch_native, "~> 0.3.0", [hex: :bunch_native, repo: "hexpm", optional: false]}, {:bundlex, "~> 0.4.0", [hex: :bundlex, repo: "hexpm", optional: false]}], "hexpm", "05b2cc456eb549bd40a53bf641c47008acba0185f25c1906b934b0b91c36f1c4"},
   "telemetry": {:hex, :telemetry, "0.4.2", "2808c992455e08d6177322f14d3bdb6b625fbcfd233a73505870d8738a2f4599", [:rebar3], [], "hexpm", "2d1419bd9dda6a206d7b5852179511722e2b18812310d304620c7bd92a13fcef"},
-  "unifex": {:git, "https://github.com/membraneframework/unifex.git", "3f25764376805e8fe3f6061399298bc3b1703364", []},
+  "unifex": {:hex, :unifex, "0.3.2", "93a183348e9ee950f0b942a530452fff1eaddad29c9d3f0311219176b8a310bd", [:mix], [{:bunch, "~> 1.0", [hex: :bunch, repo: "hexpm", optional: false]}, {:bundlex, "~> 0.4.0", [hex: :bundlex, repo: "hexpm", optional: false]}, {:shmex, "~> 0.3.0", [hex: :shmex, repo: "hexpm", optional: false]}], "hexpm", "41694476c2c71c885fc815c486150a2dacb6bb86a4f3e21b5eda4008bc950d08"},
 }

--- a/test/ex_dtls_test.exs
+++ b/test/ex_dtls_test.exs
@@ -1,0 +1,9 @@
+defmodule ExDTLSTest do
+  use ExUnit.Case, async: true
+
+  test "cert fingerprint" do
+    {:ok, pid} = ExDTLS.start_link(client_mode: false, dtls_srtp: false)
+    {:ok, fingerprint} = ExDTLS.get_cert_fingerprint(pid)
+    assert byte_size(fingerprint) == 32
+  end
+end

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -13,7 +13,7 @@ defmodule ExDTLSTest do
   end
 
   defp loop({pid1, false}, {pid2, true}, packets) do
-    {:finished, _keying_material} = ExDTLS.do_handshake(pid1, packets)
+    {:finished, _handshake_data} = ExDTLS.do_handshake(pid1, packets)
     loop({pid2, true}, {pid1, true}, nil)
   end
 

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -22,7 +22,7 @@ defmodule ExDTLSTest do
       {:ok, packets} ->
         loop({pid2, state2}, {pid1, state1}, packets)
 
-      {:finished_with_packets, _keying_material, packets} ->
+      {:finished_with_packets, _handshake_data, packets} ->
         loop({pid2, state2}, {pid1, true}, packets)
     end
   end

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -1,4 +1,4 @@
-defmodule ExDTLSTest do
+defmodule ExDTLS.IntegrationTest do
   use ExUnit.Case, async: true
 
   test "dtls-srtp" do


### PR DESCRIPTION
Now `keying_material` will be returned with int representing protection profile according to [this](https://www.iana.org/assignments/srtp-protection/srtp-protection.xhtml). 

Also `keying_material` is no longer a single string. Now it is splitted into client and server parts and returned in binary format.

Cert fingerprint will now be returned as binary from native code as well as from `ExDTLS` module. 