### PR TITLE
Fix debug logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The package can be installed by adding `ex_dtls` to your list of dependencies in
 ```elixir
 def deps do
   [
-    {:ex_dtls, "~> 0.2.0"}
+    {:ex_dtls, "~> 0.2.1"}
   ]
 end
 ```

--- a/c_src/ex_dtls/dtls.c
+++ b/c_src/ex_dtls/dtls.c
@@ -1,11 +1,5 @@
 #include "dtls.h"
 
-#ifdef CNODE_DEBUG
-#define DEBUG(X, ...) fprintf(stderr, X "\r\n", ##__VA_ARGS__)
-#else
-#define DEBUG(...)
-#endif
-
 SSL_CTX *create_ctx(int dtls_srtp) {
   SSL_CTX *ssl_ctx = SSL_CTX_new(DTLS_method());
   if (ssl_ctx == NULL) {

--- a/c_src/ex_dtls/dtls.h
+++ b/c_src/ex_dtls/dtls.h
@@ -6,6 +6,8 @@
 #include <openssl/x509.h>
 #include <string.h>
 
+#include "log.h"
+
 typedef struct KeyingMaterial {
   unsigned char *client; // client keying material - master key + master salt
   unsigned char *server;

--- a/c_src/ex_dtls/log.h
+++ b/c_src/ex_dtls/log.h
@@ -1,0 +1,5 @@
+#ifdef CNODE_DEBUG
+#define DEBUG(X, ...) fprintf(stderr, X "\r\n", ##__VA_ARGS__)
+#else
+#define DEBUG(...)
+#endif

--- a/c_src/ex_dtls/native.c
+++ b/c_src/ex_dtls/native.c
@@ -8,10 +8,6 @@
 
 #define BUF_LEN 2048
 
-#define DEBUG(X, ...)                                                          \
-  printf(X "\n", ##__VA_ARGS__);                                               \
-  fflush(stdout);
-
 UNIFEX_TERM init(UnifexEnv *env, int client_mode, int dtls_srtp) {
   UNIFEX_TERM res_term;
   State *state = unifex_alloc_state(env);

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExDTLS.Mixfile do
   use Mix.Project
 
-  @version "0.2.0"
+  @version "0.2.1"
   @github_url "https://github.com/membraneframework/ex_dtls"
 
   def project do


### PR DESCRIPTION
Some DEBUG logs were always printed. Now they will be printed only when `CNODE_DEBUG` flag is set.