### PR TITLE
Handle returning empty packets from `do_handshake/2`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The package can be installed by adding `ex_dtls` to your list of dependencies in
 ```elixir
 def deps do
   [
-    {:ex_dtls, "~> 0.2.1"}
+    {:ex_dtls, "~> 0.3.0"}
   ]
 end
 ```

--- a/c_src/ex_dtls/native.spec.exs
+++ b/c_src/ex_dtls/native.spec.exs
@@ -9,12 +9,8 @@ spec init(client_mode :: bool, dtls_srtp :: bool) :: {:ok :: label, state}
 spec get_cert_fingerprint(state) :: {:ok :: label, state, fingerprint :: payload}
 
 spec do_handshake(state, packets :: payload) :: {:ok :: label, state, packets :: payload}
-                            | {:finished_with_packets :: label, state,
+                            | {:finished :: label, state,
                                 client_keying_material :: payload,
                                 server_keying_material :: payload,
                                 protection_profile :: int,
                                 packets :: payload}
-                            | {:finished :: label, state,
-                                client_keying_material :: payload,
-                                server_keying_material :: payload,
-                                protection_profile :: int}

--- a/lib/ex_dtls.ex
+++ b/lib/ex_dtls.ex
@@ -132,7 +132,7 @@ defmodule ExDTLS do
           )
 
         handshake_data = {local_km, remote_km, protection_profile}
-        msg = {:finished_with_packets, handshake_data, packets}
+        msg = {:finished, handshake_data, packets}
         {:reply, msg, state}
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExDTLS.Mixfile do
   use Mix.Project
 
-  @version "0.2.1"
+  @version "0.3.0"
   @github_url "https://github.com/membraneframework/ex_dtls"
 
   def project do

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -22,7 +22,7 @@ defmodule ExDTLS.IntegrationTest do
       {:ok, packets} ->
         loop({pid2, state2}, {pid1, state1}, packets)
 
-      {:finished_with_packets, _handshake_data, packets} ->
+      {:finished, _handshake_data, packets} ->
         loop({pid2, state2}, {pid1, true}, packets)
     end
   end


### PR DESCRIPTION
`do_handshake/2` can return without generated packets. Now we will return `:ok` in such situation or `{:ok, packets}` in other case