### PR TITLE
Add workaround for retransmission after successful handshake

### DIFF
--- a/c_src/ex_dtls/native.c
+++ b/c_src/ex_dtls/native.c
@@ -247,6 +247,9 @@ UNIFEX_TERM handle_read_error(State *state, int ret) {
   switch (error) {
   case SSL_ERROR_ZERO_RETURN:
     return process_result_connection_closed_peer_closed_for_writing(state->env);
+  case SSL_ERROR_WANT_READ:
+    DEBUG("SSL WANT READ. This is workaround. Did we get retransmission?")
+    return process_result_hsk_want_read(state->env);
   default:
     DEBUG("SSL ERROR: %d", error);
     return unifex_raise(state->env, "SSL read error");


### PR DESCRIPTION
This is small workaround for scenario when we get retransmission after successful handshake. It will be removed in #6. 
closes #11 