### PR TITLE
Allow ExDTLS to run in a NIF

### DIFF
--- a/bundlex.exs
+++ b/bundlex.exs
@@ -14,7 +14,7 @@ defmodule ExDTLS.BundlexProject do
         deps: [unifex: :unifex],
         pkg_configs: ["openssl"],
         libs: ["pthread"],
-        interface: :cnode,
+        interface: [:nif, :cnode],
         preprocessor: Unifex
       ]
     ]

--- a/c_src/ex_dtls/native.spec.exs
+++ b/c_src/ex_dtls/native.spec.exs
@@ -1,6 +1,6 @@
 module ExDTLS.Native
 
-interface CNode
+interface [NIF, CNode]
 
 state_type "State"
 
@@ -8,25 +8,25 @@ spec init(client_mode :: bool, dtls_srtp :: bool) :: {:ok :: label, state}
 
 spec init_from_key_cert(client_mode :: bool, dtls_srtp :: bool, pkey :: payload, cert :: payload) :: {:ok :: label, state}
 
-spec generate_cert() :: {:ok :: label, cert :: payload}
+spec generate_cert(state) :: {{:ok :: label, cert :: payload}, state}
 
-spec get_pkey(state) :: {:ok :: label, pkey :: payload}
+spec get_pkey(state) :: {{:ok :: label, pkey :: payload}, state}
 
-spec get_cert(state) :: {:ok :: label, cert :: payload}
+spec get_cert(state) :: {{:ok :: label, cert :: payload}, state}
 
-spec get_cert_fingerprint(state) :: {:ok :: label, state, fingerprint :: payload}
+spec get_cert_fingerprint(state) :: {{:ok :: label, fingerprint :: payload}, state}
 
-spec do_handshake(state) :: {:ok :: label, state, packets :: payload}
+spec do_handshake(state) :: {{:ok :: label, packets :: payload}, state}
 
 spec handle_timeout(state) :: {:ok :: label, state}
-                           | {:retransmit :: label, state, packets :: payload}
+                           | {{:retransmit :: label, packets :: payload}, state}
 
 spec process(state, packets :: payload) :: {:ok :: label, state, packets :: payload}
-                                           | (:hsk_want_read :: label)
-                                           | {:hsk_packets :: label, state, packets :: payload}
-                                           | {:hsk_finished :: label, state,
+                                           | {(:hsk_want_read :: label), state}
+                                           | {{:hsk_packets :: label, packets :: payload}, state}
+                                           | {{:hsk_finished :: label,
                                               client_keying_material :: payload,
                                               server_keying_material :: payload,
                                               protection_profile :: int,
-                                              packets :: payload}
-                                           | {:connection_closed :: label, :peer_closed_for_writing :: label}
+                                              packets :: payload}, state}
+                                           | {{:connection_closed :: label, :peer_closed_for_writing :: label}, state}

--- a/lib/ex_dtls/native.ex
+++ b/lib/ex_dtls/native.ex
@@ -1,0 +1,4 @@
+defmodule ExDTLS.Native do
+  @moduledoc false
+  use Unifex.Loader
+end

--- a/test/ex_dtls_test.exs
+++ b/test/ex_dtls_test.exs
@@ -1,44 +1,51 @@
 defmodule ExDTLSTest do
   use ExUnit.Case, async: true
 
-  test "start with custom cert" do
-    {:ok, pid} = ExDTLS.start_link(client_mode: false, dtls_srtp: false)
-    {:ok, pkey} = ExDTLS.get_pkey(pid)
-    {:ok, cert} = ExDTLS.get_cert(pid)
+  for impl <- [NIF, CNode] do
+    @implementation impl
+    describe "#{@implementation}" do
+      test "start with custom cert" do
+        {:ok, pid} =
+          ExDTLS.start_link(impl: @implementation, client_mode: false, dtls_srtp: false)
 
-    assert {:ok, pid2} =
-             ExDTLS.start_link(client_mode: false, dtls_srtp: false, pkey: pkey, cert: cert)
+        {:ok, pkey} = ExDTLS.get_pkey(pid)
+        {:ok, cert} = ExDTLS.get_cert(pid)
 
-    assert {:ok, pid3} =
-             ExDTLS.start_link(client_mode: false, dtls_srtp: false, pkey: pkey, cert: cert)
+        assert {:ok, pid2} =
+                 ExDTLS.start_link(client_mode: false, dtls_srtp: false, pkey: pkey, cert: cert)
 
-    assert ExDTLS.get_pkey(pid2) == ExDTLS.get_pkey(pid3)
-    assert ExDTLS.get_cert(pid2) == ExDTLS.get_cert(pid3)
-  end
+        assert {:ok, pid3} =
+                 ExDTLS.start_link(client_mode: false, dtls_srtp: false, pkey: pkey, cert: cert)
 
-  test "cert fingerprint" do
-    {:ok, pid} = ExDTLS.start_link(client_mode: false, dtls_srtp: false)
-    {:ok, fingerprint} = ExDTLS.get_cert_fingerprint(pid)
-    assert byte_size(fingerprint) == 32
-  end
+        assert ExDTLS.get_pkey(pid2) == ExDTLS.get_pkey(pid3)
+        assert ExDTLS.get_cert(pid2) == ExDTLS.get_cert(pid3)
+      end
 
-  test "get pkey" do
-    {:ok, pid} = ExDTLS.start_link(client_mode: false, dtls_srtp: false)
-    assert {:ok, _pkey} = ExDTLS.get_pkey(pid)
-  end
+      test "cert fingerprint" do
+        {:ok, pid} = ExDTLS.start_link(client_mode: false, dtls_srtp: false)
+        {:ok, fingerprint} = ExDTLS.get_cert_fingerprint(pid)
+        assert byte_size(fingerprint) == 32
+      end
 
-  test "get cert" do
-    {:ok, pid} = ExDTLS.start_link(client_mode: false, dtls_srtp: false)
-    assert {:ok, _cert} = ExDTLS.get_cert(pid)
-  end
+      test "get pkey" do
+        {:ok, pid} = ExDTLS.start_link(client_mode: false, dtls_srtp: false)
+        assert {:ok, _pkey} = ExDTLS.get_pkey(pid)
+      end
 
-  test "generate cert" do
-    {:ok, pid} = ExDTLS.start_link(client_mode: false, dtls_srtp: false)
-    assert {:ok, _cert} = ExDTLS.generate_cert(pid)
-  end
+      test "get cert" do
+        {:ok, pid} = ExDTLS.start_link(client_mode: false, dtls_srtp: false)
+        assert {:ok, _cert} = ExDTLS.get_cert(pid)
+      end
 
-  test "stop" do
-    {:ok, pid} = ExDTLS.start_link(client_mode: false, dtls_srtp: false)
-    assert :ok = ExDTLS.stop(pid)
+      test "generate cert" do
+        {:ok, pid} = ExDTLS.start_link(client_mode: false, dtls_srtp: false)
+        assert {:ok, _cert} = ExDTLS.generate_cert(pid)
+      end
+
+      test "stop" do
+        {:ok, pid} = ExDTLS.start_link(client_mode: false, dtls_srtp: false)
+        assert :ok = ExDTLS.stop(pid)
+      end
+    end
   end
 end


### PR DESCRIPTION
This is pretty quick and dirty, but I wanted to see if I could run this as a NIF rather than a CNode. That would help not only if someone wanted to run the `membrane_rtc_engine` on an IPv6 network, but with `-proto_dist inet_tls` (which I've been playing around with in my free time).

I used the changes to `ex_libnice` that @mickel8 did a few months ago as a basis, with the caveat that I don't totally understand what is happening in unifex. In some cases, I had to change the interface to the C code—with the upside that it seems a little more internally consistent.

The tests pass for me, though it seems like the tests are not exhaustive—I ran this in a personal app using the rtc engine until I found all the crashes that I could trigger.