### PR TITLE
Improve retransmit message

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ Peer that finishes handshake first will return `{:finished, handshake_data, pack
 message. These packets have to be sent to the second peer, so it can finish its handshake too and
 return `{:finished, handshake_data}` message.
 
+`ExDTLS` may also ask for retransmitting some packets if it thinks they were lost.
+See `t:ExDTLS.retransmit_msg_t/0`.
+
 For more complete examples please refer to [membrane_ice_plugin] where we use `ex_dtls`
 or to our integration tests.
 

--- a/test/retransmission_test.exs
+++ b/test/retransmission_test.exs
@@ -22,7 +22,7 @@ defmodule ExDTLS.RetransmissionTest do
       1000 ->
         wait_for_retransmission(pid, false)
 
-      {:retransmit, ^pid, packets} ->
+      {:ex_dtls, ^pid, {:retransmit, packets}} ->
         packets
 
       _other ->


### PR DESCRIPTION
* added `:ex_dtls` atom to the `retransmit` message so that we can be sure this is a message from ExDTLS
* moved ExDTLS pid to the second position, the same as in the :gen_udp
* wrapped :retransmit and pcakets into a tuple - not sure about this one but we do the same in the ex_ice :thinking: 