### PR TITLE
Remove CNode implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,8 @@ end
 
 ## Usage
 
-`ExDTLS` can work both as a C node or as a NIF.
-By default, C node implementation is used, however, user can change it by passing proper option while starting `ExDTLS`
-or in `config.exs` by:
-
-```elixir
-config :ex_dtls, impl: :nif
-```
+`ExDTLS` uses OpenSSL under the hood.
+Make sure you have it installed on your OS.
 
 Init `ExDTLS` on both peers with:
 

--- a/bundlex.exs
+++ b/bundlex.exs
@@ -14,7 +14,7 @@ defmodule ExDTLS.BundlexProject do
         deps: [unifex: :unifex],
         pkg_configs: ["openssl"],
         libs: ["pthread"],
-        interface: [:nif, :cnode],
+        interface: [:nif],
         preprocessor: Unifex
       ]
     ]

--- a/c_src/ex_dtls/log.h
+++ b/c_src/ex_dtls/log.h
@@ -1,4 +1,4 @@
-#ifdef CNODE_DEBUG
+#ifdef EXDTLS_DEBUG
 #define DEBUG(X, ...) fprintf(stderr, X "\r\n", ##__VA_ARGS__)
 #else
 #define DEBUG(...)

--- a/c_src/ex_dtls/native.spec.exs
+++ b/c_src/ex_dtls/native.spec.exs
@@ -1,6 +1,6 @@
 module ExDTLS.Native
 
-interface [NIF, CNode]
+interface NIF
 
 state_type "State"
 

--- a/test/ex_dtls_test.exs
+++ b/test/ex_dtls_test.exs
@@ -1,68 +1,45 @@
 defmodule ExDTLSTest do
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
 
-  @app :ex_dtls
-  setup_all do
-    backup = Application.get_env(@app, :impl)
+  test "start with custom cert" do
+    {:ok, pid} = ExDTLS.start_link(client_mode: false, dtls_srtp: false)
 
-    on_exit(fn -> Application.put_env(@app, :impl, backup) end)
+    {:ok, pkey} = ExDTLS.get_pkey(pid)
+    {:ok, cert} = ExDTLS.get_cert(pid)
+
+    assert {:ok, pid2} =
+             ExDTLS.start_link(client_mode: false, dtls_srtp: false, pkey: pkey, cert: cert)
+
+    assert {:ok, pid3} =
+             ExDTLS.start_link(client_mode: false, dtls_srtp: false, pkey: pkey, cert: cert)
+
+    assert ExDTLS.get_pkey(pid2) == ExDTLS.get_pkey(pid3)
+    assert ExDTLS.get_cert(pid2) == ExDTLS.get_cert(pid3)
   end
 
-  for impl <- [:nif, :cnode] do
-    @implementation impl
-    describe "#{@implementation}" do
-      setup do
-        Application.put_env(@app, :impl, @implementation)
-      end
-
-      test "start with custom cert" do
-        {:ok, pid} = ExDTLS.start_link(client_mode: false, dtls_srtp: false)
-
-        {:ok, pkey} = ExDTLS.get_pkey(pid)
-        {:ok, cert} = ExDTLS.get_cert(pid)
-
-        assert {:ok, pid2} =
-                 ExDTLS.start_link(client_mode: false, dtls_srtp: false, pkey: pkey, cert: cert)
-
-        assert {:ok, pid3} =
-                 ExDTLS.start_link(client_mode: false, dtls_srtp: false, pkey: pkey, cert: cert)
-
-        assert ExDTLS.get_pkey(pid2) == ExDTLS.get_pkey(pid3)
-        assert ExDTLS.get_cert(pid2) == ExDTLS.get_cert(pid3)
-      end
-
-      test "cert fingerprint" do
-        {:ok, pid} = ExDTLS.start_link(client_mode: false, dtls_srtp: false)
-        {:ok, fingerprint} = ExDTLS.get_cert_fingerprint(pid)
-        assert byte_size(fingerprint) == 32
-      end
-
-      test "get pkey" do
-        {:ok, pid} = ExDTLS.start_link(client_mode: false, dtls_srtp: false)
-        assert {:ok, _pkey} = ExDTLS.get_pkey(pid)
-      end
-
-      test "get cert" do
-        {:ok, pid} = ExDTLS.start_link(client_mode: false, dtls_srtp: false)
-        assert {:ok, _cert} = ExDTLS.get_cert(pid)
-      end
-
-      test "generate cert" do
-        {:ok, pid} = ExDTLS.start_link(client_mode: false, dtls_srtp: false)
-        assert {:ok, _cert} = ExDTLS.generate_cert(pid)
-      end
-
-      test "stop" do
-        {:ok, pid} = ExDTLS.start_link(client_mode: false, dtls_srtp: false)
-        assert :ok = ExDTLS.stop(pid)
-      end
-    end
+  test "cert fingerprint" do
+    {:ok, pid} = ExDTLS.start_link(client_mode: false, dtls_srtp: false)
+    {:ok, fingerprint} = ExDTLS.get_cert_fingerprint(pid)
+    assert byte_size(fingerprint) == 32
   end
 
-  test "Invalid impl" do
-    Application.put_env(@app, :impl, :invalid)
+  test "get pkey" do
+    {:ok, pid} = ExDTLS.start_link(client_mode: false, dtls_srtp: false)
+    assert {:ok, _pkey} = ExDTLS.get_pkey(pid)
+  end
 
-    assert {:error, {%ArgumentError{}, _stacktrace}} =
-             ExDTLS.start(client_mode: false, dtls_srtp: false)
+  test "get cert" do
+    {:ok, pid} = ExDTLS.start_link(client_mode: false, dtls_srtp: false)
+    assert {:ok, _cert} = ExDTLS.get_cert(pid)
+  end
+
+  test "generate cert" do
+    {:ok, pid} = ExDTLS.start_link(client_mode: false, dtls_srtp: false)
+    assert {:ok, _cert} = ExDTLS.generate_cert(pid)
+  end
+
+  test "stop" do
+    {:ok, pid} = ExDTLS.start_link(client_mode: false, dtls_srtp: false)
+    assert :ok = ExDTLS.stop(pid)
   end
 end

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -1,24 +1,7 @@
 defmodule ExDTLS.IntegrationTest do
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
 
-  @app :ex_dtls
-  setup_all do
-    backup = Application.get_env(@app, :impl)
-
-    on_exit(fn -> Application.put_env(@app, :impl, backup) end)
-  end
-
-  test "NIF dtls_srtp" do
-    Application.put_env(@app, :impl, :nif)
-    run_test()
-  end
-
-  test "CNode dtls_srtp" do
-    Application.put_env(@app, :impl, :cnode)
-    run_test()
-  end
-
-  defp run_test() do
+  test "dtls_srtp" do
     {:ok, rx_pid} = ExDTLS.start_link(client_mode: false, dtls_srtp: true)
     {:ok, tx_pid} = ExDTLS.start_link(client_mode: true, dtls_srtp: true)
     {:ok, packets} = ExDTLS.do_handshake(tx_pid)


### PR DESCRIPTION
A couple of things:
* we always use NIF implementation
* in the next PR I would like to remove GenServer and convert this repo to a plain module to limit message passing
* Erlang relies on OpenSSL so I would assume it's pretty safe to use it as a NIF 
* I didn't see people writing CNodes